### PR TITLE
Update test configurations for SECRET_KEY and DEFAULT_AUTO_FIELD

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,6 +9,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).parent.resolve()
 
-SECRET_KEY = "NOBODY expects the Spanish Inquisition!"
+SECRET_KEY = "django-insecure-test-key-not-for-production"
+
 DEBUG = True
 
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
## Description

- Self-documenting `SECRET_KEY` - replace the joke placeholder with django-insecure-test-key-not-for-production, following Django's django-insecure- convention so it's obvious the key is a throwaway used only by the test suite.

- Explicit `DEFAULT_AUTO_FIELD` - set to `django.db.models.AutoField` to silence Django's auto-field warning and pin the primary key type for test models.

<img width="1064" height="621" alt="image" src="https://github.com/user-attachments/assets/f5a5f3c6-ee03-4687-98e4-1542484706eb" />
