### PR TITLE
fix(deps): relax django-haystack constraint to >=3.3.0,<4

### DIFF
--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,6 +1,6 @@
 coverage
 django==4.2.30
-django-haystack>=2.8,<=3.2
+django-haystack>=3.3.0,<4
 djangorestframework>=3.7.0,<=3.13
 elasticsearch>=2.0.0,<=8.3.3
 sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "django>=4.2,<5.2",
-    "django-haystack>=2.8,<3.4",
+    "django-haystack>=3.3.0,<4",
     "djangorestframework>=3.12,<3.16",
     "python-dateutil",
 ]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "Django>=4.2,<5.2",
         "djangorestframework>=3.12,<3.16",
-        "django-haystack>=2.8,<3.4",
+        "django-haystack>=3.3.0,<4",
         "python-dateutil",
     ],
     tests_require=["coverage", "geopy", "requests"],


### PR DESCRIPTION
## Description

Fixes: #298 


[django-haystack](https://github.com/django-haystack/django-haystack/blob/v3.3.0/pyproject.toml#L19) 3.3.0 is the first release in the series to support Django 4.2 LTS.
 none of the earlier versions do. Since `drf-haystack` itself supports only Django 4.2 LTS and above, the minimum version constraint is also raised to match.
