### PR TITLE
Remove support for EOL Django Rest Framework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,25 +35,8 @@ jobs:
         elastic-version:
           - "7.17.29"
         drf-version:
-          - "3.12.*"
-          - "3.13.*"
-          - "3.14.*"
-          - "3.15.*"
-        exclude:
-          # DRF 3.12 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
-          - drf-version: "3.12.*"
-
-          # DRF 3.13 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
-          - drf-version: "3.13.*"
-
-          # DRF 3.13 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
-          - drf-version: "3.14.*"
-
-          # DRF 3.15
-          - drf-version: "3.15.*"
-            python-version: "3.13"
-          - drf-version: "3.15.*"
-            python-version: "3.14"
+          - "3.16.*"
+          - "3.17.*"
 
     env:
       UV_NO_DEV: 1

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported versions
 - Python >=3.11, <3.15
 - Django >=5.2,<5.3
 - Haystack >=2.8,<3.4
-- Django REST Framework >=3.12.0,<3.16
+- Django REST Framework >=3.16
 - elasticsearch >=2.0.0,<=8.3.3,
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ It's in the cheese shop!
 Requirements
 ============
     - A Supported Django install
-    - Django REST Framework v3.2.0 and later
+    - Django REST Framework v3.16 and later
     - Haystack v2.5 and later
     - A supported search engine such as Solr, Elasticsearch, Whoosh, etc.
     - Python bindings for the chosen backend (see below).

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,7 +1,7 @@
 coverage
 django==5.2.16
 django-haystack>=3.3.0,<4
-djangorestframework>=3.7.0,<=3.13
+djangorestframework>=3.16
 elasticsearch>=2.0.0,<=8.3.3
 sphinx
 sphinx-rtd-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "django>=5.2,<5.3",
     "django-haystack>=3.3.0,<4",
-    "djangorestframework>=3.12,<3.16",
+    "djangorestframework>=3.16",
     "python-dateutil",
 ]
 urls.Documentation = "https://drf-haystack.readthedocs.io"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=5.2,<5.3",
-        "djangorestframework>=3.12,<3.16",
+        "djangorestframework>=3.16",
         "django-haystack>=3.3.0,<4",
         "python-dateutil",
     ],


### PR DESCRIPTION
## Description

*Drop support for end-of-life Django REST Framework versions.*

Django REST Framework **3.16.0** is the first release that supports Django **5.2**

See: https://www.django-rest-framework.org/community/release-notes/#3160

<img width="565" height="342" alt="drf" src="https://github.com/user-attachments/assets/56a1cec5-18ef-4e6c-a448-1f342ec1811a" />

After this change, the CI tests with Django 6 in PR #308 will also pass.

### Tests

`% uv run --with django==6.0.* --with djangorestframework==3.16 manage.py test`
<img width="880" height="107" alt="{7CF2AED8-09FE-4CFD-88B2-7643B8EEA2ED}" src="https://github.com/user-attachments/assets/65e58ed4-3584-4cf3-ac75-b94b9b86f1b0" />

