### PR TITLE
Remove deprecated license classifier from packaging configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "drf-haystack"
 version = "1.9.1"
 description = "Makes Haystack play nice with Django REST Framework"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "Dhaval Gojiya", email = "dhavalgojiya10@gmail.com" },
     { name = "Rolf Håvard Blindheim", email = "rhblind@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Description

See: https://peps.python.org/pep-0639/#deprecate-license-classifiers