### PR TITLE
refactor(packaging): Derive __version__ from installed package metadata

### DIFF
--- a/drf_haystack/__init__.py
+++ b/drf_haystack/__init__.py
@@ -1,9 +1,15 @@
 import warnings
+from importlib.metadata import PackageNotFoundError, version
 
 __title__ = "drf-haystack"
-__version__ = "1.9.1"
 __author__ = "Rolf Haavard Blindheim"
 __license__ = "MIT License"
+
+
+try:
+    __version__ = version("drf-haystack")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 VERSION = __version__
 


### PR DESCRIPTION
## Description

**Fixes**: #330 

See: https://docs.python.org/3/library/importlib.metadata.html#overview

### Tests

1 - **When package is install (editable/non-editable)**
<img width="1227" height="176" alt="image" src="https://github.com/user-attachments/assets/8001a759-9256-46ed-b891-5caf0fbd14a8" />

2 - **When package is not install** 
Note: This only happens when end users directly copy and paste the `drf_haystack` folder into their virtual environment's `site-packages` directory without the `.dist-info` metadata folder. (Highly unlikely)
<img width="1269" height="191" alt="image" src="https://github.com/user-attachments/assets/9aae128f-19a5-4d7d-8fd9-f2cd53a33ce6" />
