### PR TITLE
Bump Django upper bound to <6.2 in project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "django>=5.2,<6.1",
+    "django>=5.2,<6.2",
     "django-haystack>=3.3.0,<4",
     "djangorestframework>=3.16",
     "python-dateutil",


### PR DESCRIPTION
## Description

This change was missed in the following PR: https://github.com/ulgens/drf-haystack/pull/342