### PR TITLE
ci(tests): Cap the docker Elasticsearch startup wait

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends gdal-bin
 
       - name: Start Elasticsearch
-        run: docker compose up -d --quiet-pull --wait elasticsearch
+        run: docker compose up --quiet-pull --wait --wait-timeout 120 elasticsearch
 
       - name: Setup project and install dependencies
         run: uv sync


### PR DESCRIPTION
## Description

- `-d` is redundant when using `--wait`. See: [Docker docs](https://docs.docker.com/reference/cli/docker/compose/up/)
- Cap the Docker Elasticsearch startup wait at 120 seconds to prevent infinite blocking.

_Aims to improve existing setup, not a bug fix_